### PR TITLE
Add Passport to Middleware section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Curated list of express.js resources
 - [errorhandler](https://github.com/expressjs/errorhandler) - development-only error handler middleware
 - [serve-favicon](https://github.com/expressjs/serve-favicon) - favicon serving middleware
 - [csurf](https://github.com/expressjs/csurf) - node.js CSRF protection middleware
+- [Passport](http://www.passportjs.org/) - Simple, unobtrusive authentication
 
 ## Microservices
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Curated list of express.js resources
 - [errorhandler](https://github.com/expressjs/errorhandler) - development-only error handler middleware
 - [serve-favicon](https://github.com/expressjs/serve-favicon) - favicon serving middleware
 - [csurf](https://github.com/expressjs/csurf) - node.js CSRF protection middleware
-- [Passport](http://www.passportjs.org/) - Simple, unobtrusive authentication
+- [Passport](http://www.passportjs.org) - Simple, unobtrusive authentication
 
 ## Microservices
 


### PR DESCRIPTION
Added a reference to Passport to the Middleware section. While it's not only for Express, it's common to use it for Express for authentication purposes.