### PR TITLE
Add Pino logger package

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Curated list of express.js resources
 - [express-actuator](https://github.com/rcruzper/express-actuator) - Middleware with endpoints to help you monitor and manage applications through healthchecks
 - [express-decorator-router](https://github.com/LucasMendesl/express-decorator-router) - Use decorators in a simple way without transpiling Javascript code
 - [sonic-express](https://github.com/Tiemma/sonic-express) - Automate generating swagger docs for your API endpoints without writing any docs
+- [express-pino-logger](https://github.com/pinojs/express-pino-logger) - Use the fast, low overhead Pino logger to log each request.
 
 ## Microservices
 


### PR DESCRIPTION
Added middleware for Pino logger package to README file. This package is
an alternative to Morgan to log the requests. Pino is a fast logger with
lower overhead to Morgan, which I think is worth adding.