### PR TITLE
Add express-fast-json-stringify

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Curated list of express.js resources
 - [express-pino-logger](https://github.com/pinojs/express-pino-logger) - Use the fast, low overhead Pino logger to log each request.
 - [express-validator](https://github.com/express-validator/express-validator) - express-validator is a set of express.js middlewares that wraps validator.js validator and sanitizer functions.
 - [express-response-hooks](https://github.com/arikw/express-response-hooks) - Intercept and mutate responses before they are sent to the client
+- [express-fast-json-stringify](https://www.npmjs.com/package/express-fast-json-stringify) - With express-fast-json-stringify, you can leverage fast-json-stringify in your Express application
 
 ## Microservices
 


### PR DESCRIPTION
One of the reasons why [Fastify](https://www.npmjs.com/package/fastify) is faster than Express is its use of [fast-json-stringify](https://www.npmjs.com/package/fast-json-stringify). fast-json-stringify is a library developed by the Fastify team that boosts JSON conversion speed by analyzing JSON schema definitions.

See the stackblitz [demo](https://stackblitz.com/edit/express-fast-json-stringify).

By using the fast-json-stringify library, Fastify can serialize JSON much faster than Express, contributing to its overall performance advantage.

With express-fast-json-stringify, you can leverage fast-json-stringify in your Express application

https://www.npmjs.com/package/express-fast-json-stringify
https://github.com/nigrosimone/express-fast-json-stringify